### PR TITLE
[WIP] Add option to specify a proxy client for results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
+- Config option to provide a proxy client name for serverspec results
 
 ### Fixed
 - PR template spelling

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 ## Usage
 
+Run tests with a specified proxy client
+
+`check-serverspec.rb -d /tmp/my_tests -s spec/my_tests.rb --proxy-client serverspec-client`
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/bin/check-serverspec.rb
+++ b/bin/check-serverspec.rb
@@ -56,6 +56,11 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
          long: '--handler HANDLER',
          default: 'default'
 
+  option :proxy_client,
+         description: 'Proxy client name for results',
+         long: '--proxy-client SOURCE',
+         required: false
+
   def sensu_client_socket(msg)
     u = UDPSocket.new
     u.send(msg + "\n", 0, '127.0.0.1', 3030)
@@ -81,17 +86,17 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
   end
 
   def send_ok(check_name, msg)
-    d = { 'name' => check_name, 'status' => 0, 'output' => 'OK: ' + msg, 'handler' => config[:handler] }
+    d = { 'name' => check_name, 'status' => 0, 'output' => 'OK: ' + msg, 'handler' => config[:handler], 'source' => config[:proxy_client] }
     sensu_client_socket d.to_json
   end
 
   def send_warning(check_name, msg)
-    d = { 'name' => check_name, 'status' => 1, 'output' => 'WARNING: ' + msg, 'handler' => config[:handler] }
+    d = { 'name' => check_name, 'status' => 1, 'output' => 'WARNING: ' + msg, 'handler' => config[:handler], 'source' => config[:proxy_client] }
     sensu_client_socket d.to_json
   end
 
   def send_critical(check_name, msg)
-    d = { 'name' => check_name, 'status' => 2, 'output' => 'CRITICAL: ' + msg, 'handler' => config[:handler] }
+    d = { 'name' => check_name, 'status' => 2, 'output' => 'CRITICAL: ' + msg, 'handler' => config[:handler], 'source' => config[:proxy_client] }
     sensu_client_socket d.to_json
   end
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

This is a copied implementation of https://github.com/sensu-plugins/sensu-plugins-rspec/pull/4

`check-serverspec.rb` makes use of the Sensu client socket to send individual check results for each given Serverspec test. Due to this, setting a source/proxy client within the check definition itself has no affect, as the individual results are sent 'separately' to the socket, and will always appear as a check result for the host that the check was ran on.

This change introduces an additional config option to specify a source/proxy client so that all Serverspec results can be correctly sent with the source attribute. This has to be a config option as the plugin does not have context on the check attributes, so it is not possible to read in the source attribute from the check definition if present (i.e. https://github.com/sensu/sensu/issues/1586)

The `source` attribute is included in the result regardless of whether the config option is specified (as opposed to adding a case statement or something similar), however when not specified this value results to null, which the client silently ignores.

#### Known Compatability Issues

This should have no compatibility issues; checks not using this new flag will have the source value set to null, which will result in no behavioural differences at runtime.
