### PR TITLE
Index test results to ensure unique namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
+- Config option to add index value to results to prevent duplicate tests overwriting each other
 
 ### Fixed
 - PR template spelling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
-- Config option to add index value to results to prevent duplicate tests overwriting each other
+
+### Breaking Changes
+- Check result names will now be appended with a unique index value to ensure a unique namespace for all results
 
 ### Fixed
 - PR template spelling

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 ## Usage
 
+Run test suite:
+
+`check-serverspec -d /tmp/my_tests -t spec/my_tests_spec.rb`
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/bin/check-serverspec.rb
+++ b/bin/check-serverspec.rb
@@ -119,6 +119,7 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
                     serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s + '_' + index.to_s
                   else
                     serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s
+                  end
       output = serverspec_test['full_description'].delete!('"')
 
       if serverspec_test['status'] == 'passed'

--- a/bin/check-serverspec.rb
+++ b/bin/check-serverspec.rb
@@ -56,6 +56,11 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
          long: '--handler HANDLER',
          default: 'default'
 
+  option :index_results,
+         description: 'Append extra index value to rspec results',
+         long: '--index-results',
+         default: false
+
   def sensu_client_socket(msg)
     u = UDPSocket.new
     u.send(msg + "\n", 0, '127.0.0.1', 3030)
@@ -108,8 +113,12 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
     end
     parsed = JSON.parse(serverspec_results)
 
-    parsed['examples'].each do |serverspec_test|
-      test_name = serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s
+    parsed['examples'].each_with_index do |serverspec_test, index|
+      test_name = case config[:index_results]
+                  when true
+                    serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s + '_' + index.to_s
+                  else
+                    serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s
       output = serverspec_test['full_description'].delete!('"')
 
       if serverspec_test['status'] == 'passed'

--- a/bin/check-serverspec.rb
+++ b/bin/check-serverspec.rb
@@ -56,11 +56,6 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
          long: '--handler HANDLER',
          default: 'default'
 
-  option :index_results,
-         description: 'Append extra index value to rspec results',
-         long: '--index-results',
-         default: false
-
   def sensu_client_socket(msg)
     u = UDPSocket.new
     u.send(msg + "\n", 0, '127.0.0.1', 3030)
@@ -114,12 +109,7 @@ class CheckServerspec < Sensu::Plugin::Check::CLI
     parsed = JSON.parse(serverspec_results)
 
     parsed['examples'].each_with_index do |serverspec_test, index|
-      test_name = case config[:index_results]
-                  when true
-                    serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s + '_' + index.to_s
-                  else
-                    serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s
-                  end
+      test_name = serverspec_test['file_path'].split('/')[-1] + '_' + serverspec_test['line_number'].to_s + '_' + index.to_s
       output = serverspec_test['full_description'].delete!('"')
 
       if serverspec_test['status'] == 'passed'


### PR DESCRIPTION
## Pull Request Checklist

Existing issue: https://github.com/sensu-plugins/sensu-plugins-serverspec/issues/3
Matching PR: https://github.com/sensu-plugins/sensu-plugins-rspec/pull/6

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

This change adds an index value to the end of all test results, to ensure all tests have a unique name. The current implementation is flawed for uses where loops are used in tests, as several results have the same name and as such overwrite each other.

See https://github.com/sensu-plugins/sensu-plugins-rspec/pull/6 for more info

#### Known Compatability Issues

This will change the default naming convention of check results which might affect users existing filters/mutators around this check.
